### PR TITLE
Views for showing only outdated and latest packages 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/migrations/20230727020133_view_for_latest_outdated_packages.down.sql
+++ b/migrations/20230727020133_view_for_latest_outdated_packages.down.sql
@@ -1,0 +1,5 @@
+-- Revert adding views to query latest packages and outdated packages
+
+DROP VIEW IF EXISTS v_packages_latest;
+DROP VIEW IF EXISTS v_packages_outdated;
+DROP VIEW IF EXISTS v_packages_ordered;

--- a/migrations/20230727020133_view_for_latest_outdated_packages.up.sql
+++ b/migrations/20230727020133_view_for_latest_outdated_packages.up.sql
@@ -1,0 +1,31 @@
+-- Add views to query latest packages and outdated packages
+
+CREATE OR REPLACE VIEW v_packages_ordered AS
+(
+SELECT package,
+       repo,
+       version,
+       architecture,
+       rank() OVER (PARTITION BY package, repo, architecture ORDER BY _vercomp DESC) AS pos
+FROM pv_packages
+    );
+
+CREATE OR REPLACE VIEW v_packages_latest AS
+(
+SELECT package,
+       repo,
+       version,
+       architecture
+FROM v_packages_ordered
+WHERE pos = 1
+    );
+
+CREATE OR REPLACE VIEW v_packages_outdated AS
+(
+SELECT package,
+       repo,
+       version,
+       architecture
+FROM v_packages_ordered
+WHERE pos > 1
+    );


### PR DESCRIPTION
Three views are created:

- `v_packages_ordered`: compute absolute ordering over unique tuple of package name, architecture and branch.
- `v_packages_latest`: show packages with rank = 1 (i.e. latest for respective architecture and branch)
- `v_packages_outdated`: show packages with rank > 1 (i.e. superseded by a package in `v_packages_latest`)

These tables can be used:
- by administrators to manually query package state by hand;
- from scripts to obtain a list of latest packages (say my mirror serving only latest packages);
- for package retirement operations.